### PR TITLE
Add linear rollout model

### DIFF
--- a/examples/linear/Example-Train-Linear-Rollout-Model.ipynb
+++ b/examples/linear/Example-Train-Linear-Rollout-Model.ipynb
@@ -20,7 +20,7 @@
     "First, a training data set is created from historical case and npi data.\n",
     "\n",
     "Second, a linear model is trained to predict future cases from prior case data along with prior and future npi data.\n",
-    "The model is an off-the-shelf sklearn Lasso model, that uses a positive weight constraint to enforce the assumption that increased npis has a negative correlation with future cases. An independent model is trained for each number of days into the future we need to predict.\n",
+    "The model is an off-the-shelf sklearn Lasso model, that uses a positive weight constraint to enforce the assumption that increased npis has a negative correlation with future cases.\n",
     "\n",
     "Third, a sample evaluation set is created, and the predictor is applied to this evaluation set to produce prediction results in the correct format."
    ]
@@ -637,7 +637,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Created a version of the Linear Example that uses rollout instead of creating one model for each future day. Indeed, it turns out this results in a simpler model and simpler code overall (at the cost of high potential for exponential blowups).