### PR TITLE
Remove cutoff_date from LSTM example

### DIFF
--- a/examples/predictors/lstm/Example-LSTM-Predictor.ipynb
+++ b/examples/predictors/lstm/Example-LSTM-Predictor.ipynb
@@ -266,16 +266,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Consider the data after this date is not known yet\n",
-    "CUTOFF_DATE = pd.to_datetime(\"2020-07-31\", format='%Y-%m-%d')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Reload the module to get the latest changes\n",
     "import xprize_predictor\n",
     "from importlib import reload\n",
@@ -289,7 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictor = XPrizePredictor(None, DATA_FILE, CUTOFF_DATE)"
+    "predictor = XPrizePredictor(None, DATA_FILE)"
    ]
   },
   {
@@ -342,7 +332,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictor = XPrizePredictor(model_weights_file, DATA_FILE, CUTOFF_DATE)"
+    "predictor = XPrizePredictor(model_weights_file, DATA_FILE)"
    ]
   },
   {
@@ -587,7 +577,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.2"
   },
   "pycharm": {
    "stem_cell": {

--- a/examples/predictors/lstm/predict.py
+++ b/examples/predictors/lstm/predict.py
@@ -3,8 +3,6 @@
 import argparse
 import os
 
-import pandas as pd
-
 from examples.predictors.lstm.xprize_predictor import XPrizePredictor
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -14,9 +12,6 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 MODEL_WEIGHTS_FILE = os.path.join(ROOT_DIR, "models", "trained_model_weights.h5")
 
 DATA_FILE = os.path.join(ROOT_DIR, 'data', "OxCGRT_latest.csv")
-
-# Consider the data after this date is not known yet
-CUTOFF_DATE = pd.to_datetime("2020-07-31", format='%Y-%m-%d')
 
 
 def predict(start_date: str,
@@ -35,8 +30,7 @@ def predict(start_date: str,
     with columns "CountryName,RegionName,Date,PredictedDailyNewCases"
     """
     # !!! YOUR CODE HERE !!!
-    cutoff_date = pd.to_datetime(CUTOFF_DATE, format='%Y-%m-%d')
-    predictor = XPrizePredictor(MODEL_WEIGHTS_FILE, DATA_FILE, cutoff_date)
+    predictor = XPrizePredictor(MODEL_WEIGHTS_FILE, DATA_FILE)
     # Generate the predictions
     preds_df = predictor.predict(start_date, end_date, path_to_ips_file)
     # Create the output path

--- a/examples/predictors/lstm/tests/test_xprize_predictor.py
+++ b/examples/predictors/lstm/tests/test_xprize_predictor.py
@@ -15,7 +15,6 @@ DATA_FILE = os.path.join(FIXTURES_PATH, "OxCGRT_latest.csv")
 DATA_URL = "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv"
 PREDICTOR_WEIGHTS = os.path.join(FIXTURES_PATH, "trained_model_weights_for_tests.h5")
 
-CUTOFF_DATE = "2020-07-31"
 START_DATE = "2020-08-01"
 END_DATE = "2020-08-04"
 
@@ -28,11 +27,11 @@ class TestXPrizePredictor(unittest.TestCase):
         urllib.request.urlretrieve(DATA_URL, DATA_FILE)
 
     def test_predict(self):
-        predictor = XPrizePredictor(PREDICTOR_WEIGHTS, DATA_FILE, CUTOFF_DATE)
+        predictor = XPrizePredictor(PREDICTOR_WEIGHTS, DATA_FILE)
         pred_df = predictor.predict(START_DATE, END_DATE, EXAMPLE_INPUT_FILE)
         self.assertIsInstance(pred_df, pd.DataFrame)
 
     def test_train(self):
-        predictor = XPrizePredictor(None, DATA_FILE, CUTOFF_DATE)
+        predictor = XPrizePredictor(None, DATA_FILE)
         model = predictor.train()
         self.assertIsNotNone(model)

--- a/examples/predictors/lstm/xprize_predictor.py
+++ b/examples/predictors/lstm/xprize_predictor.py
@@ -168,7 +168,7 @@ class XPrizePredictor(object):
 
         return pred_new_cases
 
-    def _prepare_dataframe(self, data_url: str) -> (pd.DataFrame, pd.DataFrame):
+    def _prepare_dataframe(self, data_url: str) -> pd.DataFrame:
         """
         Loads the Oxford dataset, cleans it up and prepares the necessary columns. Depending on options, also
         loads the Johns Hopkins dataset and merges that in.

--- a/examples/prescriptors/neat/train_prescriptor.py
+++ b/examples/prescriptors/neat/train_prescriptor.py
@@ -11,7 +11,6 @@ import neat
 import numpy as np
 import pandas as pd
 
-from examples.predictors.lstm.xprize_predictor import XPrizePredictor
 from validation.cost_generator import generate_costs
 
 from utils import CASES_COL


### PR DESCRIPTION
The LSTM example use to rely on a "cutoff_date", but it's not needed anymore because the prediction now starts on start_date