### PR TITLE
Fix 'requirements-txt' typo in Examples instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ it.
 1. Activate the virtual environment
 1. Install the necessary requirements:
     ```shell script
-    pip install -r requirements-txt --upgrade
+    pip install -r requirements.txt --upgrade
     ```    
 1. Start Jupyter services:
     ```shell script


### PR DESCRIPTION
Tiny fix that might slightly smoothen the process for people going through the "Examples" instructions