### PR TITLE
Update senario_generator notebook to use fixed list of countries and regions

### DIFF
--- a/covid_xprize/validation/scenario_generator.ipynb
+++ b/covid_xprize/validation/scenario_generator.ipynb
@@ -51,7 +51,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Expecting 181 countries\n",
     "len(latest_df.CountryName.unique())"
    ]
   },
@@ -61,7 +60,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Expecting 83 regions, plus the empty one '' = 84\n",
     "len(latest_df.RegionName.unique())"
    ]
   },
@@ -141,6 +139,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -214,6 +219,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -240,6 +252,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -259,6 +278,13 @@
    "source": [
     "# Robojudge: Official\n",
     "IP file robojudge uses for its daily submissions evaluation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate"
    ]
   },
   {
@@ -294,7 +320,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Expecting 181 countries\n",
     "len(scenario_df.CountryName.unique())"
    ]
   },
@@ -304,8 +329,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Expecting 83 regions, plus the empty one '' = 84\n",
     "len(scenario_df.RegionName.unique())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save"
    ]
   },
   {

--- a/covid_xprize/validation/scenario_generator.ipynb
+++ b/covid_xprize/validation/scenario_generator.ipynb
@@ -13,9 +13,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from datetime import datetime\n",
     "import pandas as pd\n",
     "\n",
-    "from covid_xprize.validation.scenario_generator import get_raw_data, generate_scenario"
+    "from covid_xprize.scoring.predictor_scoring import load_dataset\n",
+    "from covid_xprize.validation.scenario_generator import generate_scenario"
    ]
   },
   {
@@ -38,8 +40,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DATA_FILE = \"tests/fixtures/OxCGRT_latest.csv\"\n",
-    "latest_df = get_raw_data(DATA_FILE, latest=True)"
+    "LATEST_DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'\n",
+    "GEO_FILE = \"../../countries_regions.csv\"\n",
+    "latest_df = load_dataset(LATEST_DATA_URL, GEO_FILE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Expecting 181 countries\n",
+    "len(latest_df.CountryName.unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Expecting 83 regions, plus the empty one '' = 84\n",
+    "len(latest_df.RegionName.unique())"
    ]
   },
   {
@@ -77,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario_df[scenario_df.CountryName == \"France\"].Date.max()"
+    "scenario_df[scenario_df.CountryName == \"Italy\"].Date.max()"
    ]
   },
   {
@@ -105,7 +128,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario_df.to_csv(output_file, index=False)"
+    "# Write to file\n",
+    "# scenario_df.to_csv(output_file, index=False)"
    ]
   },
   {
@@ -176,8 +200,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hist_file_name = \"data/future_ip.csv\"\n",
-    "hist_file_name"
+    "# Write to a file\n",
+    "# hist_file_name = \"data/future_ip.csv\"\n",
+    "# scenario_df.to_csv(hist_file_name, index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Robojudge test: December\n",
+    "IP file to test robojudge for the month of December"
    ]
   },
   {
@@ -186,7 +219,107 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario_df.to_csv(hist_file_name, index=False)"
+    "today = datetime.utcnow().strftime('%Y%m%d_%H%M%S')\n",
+    "start_date_str = \"2020-12-01\"\n",
+    "end_date_str = \"2020-12-31\"\n",
+    "latest_df = load_dataset(LATEST_DATA_URL, GEO_FILE)\n",
+    "countries = None\n",
+    "scenario_df = generate_scenario(start_date_str, end_date_str, latest_df, countries, scenario=\"Freeze\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check: should contain all 366 days of 2020\n",
+    "nb_countries = len(scenario_df.CountryName.unique())\n",
+    "nb_regions = len(scenario_df.RegionName.unique()) - 1  # Ignore the '' region\n",
+    "len(scenario_df) / (nb_countries + nb_regions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "sd = 20200101  # IP file always contains data since inception\n",
+    "ed = end_date_str.replace('-', \"\")\n",
+    "december_file_name = f\"../../../covid-xprize-robotasks/ips/tests/{today}_{sd}_{ed}_ips.csv\"\n",
+    "scenario_df.to_csv(december_file_name, index=False)\n",
+    "print(f\"Saved to {december_file_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Robojudge: Official\n",
+    "IP file robojudge uses for its daily submissions evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "today = datetime.utcnow().strftime('%Y%m%d_%H%M%S')\n",
+    "start_date_str = \"2020-12-22\"\n",
+    "end_date_str = \"2021-06-19\"\n",
+    "latest_df = load_dataset(LATEST_DATA_URL, GEO_FILE)\n",
+    "countries = None\n",
+    "scenario_df = generate_scenario(start_date_str, end_date_str, latest_df, countries, scenario=\"Freeze\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check: should contain 536 days:\n",
+    "# 366 days of 2020 + 170 days of 2021 (10 days in 2020 + 170 days in 2021 = 180 days of eval)\n",
+    "nb_countries = len(scenario_df.CountryName.unique())\n",
+    "nb_regions = len(scenario_df.RegionName.unique()) - 1  # Ignore the 'nan' region\n",
+    "len(scenario_df) / (nb_countries + nb_regions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Expecting 181 countries\n",
+    "len(scenario_df.CountryName.unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Expecting 83 regions, plus the empty one '' = 84\n",
+    "len(scenario_df.RegionName.unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "sd = 20200101  # IP file always contains data since inception\n",
+    "ed = end_date_str.replace('-', \"\")\n",
+    "december_file_name = f\"../../../covid-xprize-robotasks/ips/live/{today}_{sd}_{ed}_ips.csv\"\n",
+    "scenario_df.to_csv(december_file_name, index=False)\n",
+    "print(f\"Saved to {december_file_name}\")"
    ]
   },
   {
@@ -213,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Updated senario_generator notebook to use fixed list of countries and regions
- Re-generated the `covid_xprize/validation/data/2020-09-30_historical_ip.csv` example file to include only the fixed listed of countries and regions, with all the fixes Oxford made to the NPIs.