### PR TITLE
#169 Fix NEAT prescriptor sample

### DIFF
--- a/covid_xprize/examples/prescriptors/neat/utils.py
+++ b/covid_xprize/examples/prescriptors/neat/utils.py
@@ -68,6 +68,7 @@ def prepare_historical_df():
                   parse_dates=['Date'],
                   encoding="ISO-8859-1",
                   error_bad_lines=False)
+    df['RegionName'] = df['RegionName'].fillna("")
 
     # Add GeoID column for easier manipulation
     df = add_geo_id(df)


### PR DESCRIPTION
Reinstating line that replaces `NaN`s with `""` as that is what is expected later on.