### PR TITLE
#173 Remove countries and regions that are not in countries_regions.csv

### DIFF
--- a/covid_xprize/validation/data/fixed_equal_costs.csv
+++ b/covid_xprize/validation/data/fixed_equal_costs.csv
@@ -23,33 +23,6 @@ Bolivia,,1,1,1,1,1,1,1,1,1,1,1,1
 Bosnia and Herzegovina,,1,1,1,1,1,1,1,1,1,1,1,1
 Botswana,,1,1,1,1,1,1,1,1,1,1,1,1
 Brazil,,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Acre,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Alagoas,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Amapa,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Amazonas,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Bahia,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Ceara,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Distrito Federal,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Espirito Santo,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Goias,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Maranhao,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Mato Grosso,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Mato Grosso do Sul,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Minas Gerais,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Para,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Paraiba,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Parana,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Pernambuco,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Piaui,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Rio Grande do Norte,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Rio Grande do Sul,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Rio de Janeiro,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Rondonia,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Roraima,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Santa Catarina,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Sao Paulo,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Sergipe,1,1,1,1,1,1,1,1,1,1,1,1
-Brazil,Tocantins,1,1,1,1,1,1,1,1,1,1,1,1
 Brunei,,1,1,1,1,1,1,1,1,1,1,1,1
 Bulgaria,,1,1,1,1,1,1,1,1,1,1,1,1
 Burkina Faso,,1,1,1,1,1,1,1,1,1,1,1,1
@@ -190,11 +163,9 @@ Tanzania,,1,1,1,1,1,1,1,1,1,1,1,1
 Thailand,,1,1,1,1,1,1,1,1,1,1,1,1
 Timor-Leste,,1,1,1,1,1,1,1,1,1,1,1,1
 Togo,,1,1,1,1,1,1,1,1,1,1,1,1
-Tonga,,1,1,1,1,1,1,1,1,1,1,1,1
 Trinidad and Tobago,,1,1,1,1,1,1,1,1,1,1,1,1
 Tunisia,,1,1,1,1,1,1,1,1,1,1,1,1
 Turkey,,1,1,1,1,1,1,1,1,1,1,1,1
-Turkmenistan,,1,1,1,1,1,1,1,1,1,1,1,1
 Uganda,,1,1,1,1,1,1,1,1,1,1,1,1
 Ukraine,,1,1,1,1,1,1,1,1,1,1,1,1
 United Arab Emirates,,1,1,1,1,1,1,1,1,1,1,1,1
@@ -256,7 +227,6 @@ United States,Washington DC,1,1,1,1,1,1,1,1,1,1,1,1
 United States,West Virginia,1,1,1,1,1,1,1,1,1,1,1,1
 United States,Wisconsin,1,1,1,1,1,1,1,1,1,1,1,1
 United States,Wyoming,1,1,1,1,1,1,1,1,1,1,1,1
-United States Virgin Islands,,1,1,1,1,1,1,1,1,1,1,1,1
 Uruguay,,1,1,1,1,1,1,1,1,1,1,1,1
 Uzbekistan,,1,1,1,1,1,1,1,1,1,1,1,1
 Vanuatu,,1,1,1,1,1,1,1,1,1,1,1,1


### PR DESCRIPTION
Cleaned up unused countries from `covid_xprize/validation/data/fixed_equal_costs.csv`

Has been done earlier for `covid_xprize/validation/data/uniform_random_costs.csv` in https://github.com/leaf-ai/covid-xprize/pull/177