### PR TITLE
bug fix: maintain consistency in RegionName

### DIFF
--- a/covid_xprize/examples/prescriptors/neat/prescribe.py
+++ b/covid_xprize/examples/prescriptors/neat/prescribe.py
@@ -107,6 +107,7 @@ def prescribe(start_date_str: str,
 
     # Load IP costs to condition prescriptions
     cost_df = pd.read_csv(path_to_cost_file)
+    cost_df['RegionName'] = cost_df['RegionName'].fillna("")
     cost_df = add_geo_id(cost_df)
     geo_costs = {}
     for geo in geos:

--- a/covid_xprize/examples/prescriptors/neat/utils.py
+++ b/covid_xprize/examples/prescriptors/neat/utils.py
@@ -93,6 +93,7 @@ def load_ips_file(path_to_ips_file):
                      parse_dates=['Date'],
                      encoding="ISO-8859-1",
                      error_bad_lines=False)
+    df['RegionName'] = df['RegionName'].fillna("")
     df = add_geo_id(df)
     return df
 


### PR DESCRIPTION
The inconsistency in "" vs NaN caused an error where the GeoID's did not line up across the dfs.