### PR TITLE
#189 Make generate_cases_and_stringency_for_prescriptions return the generated DataFrames

### DIFF
--- a/prescriptor_robojudge.ipynb
+++ b/prescriptor_robojudge.ipynb
@@ -191,7 +191,7 @@
     "dfs = []\n",
     "for prescriptor_name, prescription_file in sorted(prescription_files.items()):\n",
     "    print(\"Generating predictions for\", prescriptor_name)\n",
-    "    df = generate_cases_and_stringency_for_prescriptions(START_DATE, END_DATE, prescription_file, TEST_COST)\n",
+    "    df, _ = generate_cases_and_stringency_for_prescriptions(START_DATE, END_DATE, prescription_file, TEST_COST)\n",
     "    df['PrescriptorName'] = prescriptor_name\n",
     "    dfs.append(df)\n",
     "df = pd.concat(dfs)"


### PR DESCRIPTION
 Make generate_cases_and_stringency_for_prescriptions return the generated DataFrames.
So that they can be persisted if needed.